### PR TITLE
Readme formatting fixes

### DIFF
--- a/AutoForward/readme.md
+++ b/AutoForward/readme.md
@@ -1,7 +1,7 @@
-#Auto Forward
+# Auto Forward
 This sample demonstrates how to automatically forward messages from a queue, subscription, or deadletter queue into another queue or topic. 
 
-##What is Auto Forwarding?
+## What is Auto Forwarding?
 
 The Auto-Forwarding feature enables you to chain the a Topic Subscription or a Queue to destination Queue or Topic that is part of the same Service Bus namespace. 
 When the feature is enabled, Service Bus automatically moves any messages arriving in the source Queue or Subscription into the destination Queue or Topic. 
@@ -18,7 +18,7 @@ destination entity.
 
 Auto-Forwarding is also available for dead-letter queues, by setting the ```QueueDescription.ForwardDeadLetteredMessagesTo``` or ```SubscriptionDescription.ForwardDeadLetteredMessagesTo``` properties. 
 
-##Why would I use it?
+## Why would I use it?
 
 Auto-Forwarding allows for a range of powerful routing patterns inside Service Bus.
 
@@ -215,14 +215,14 @@ Auto-Forwarding is charged exactly as if a user-application were to perform the 
 meaning that the cost on Service Bus Standard is two message operations (receive and send); 
 with Service Bus Premium there is no extra cost.
 
-##The Sample
+## The Sample
 
 The sample generates 3 messages: M1, M2 and M3. M1 is sent to a source topic with one subscription, from which 
 it is forwarded to a destination queue. M2 is sent to the destination queue via a transfer queue. M3 is sent to 
 a source topic with two subscriptions. One subscription forwards M3 to the destination queue. The second subscription 
 deadletters M3. Service Bus forwards this copy of M3 to the destination queue.
 
-##Description
+## Description
 
 ```C#
 QueueDescription sourceQueueDescription = new QueueDescription(SourceQueueName); 

--- a/DeadletterQueue/README.md
+++ b/DeadletterQueue/README.md
@@ -65,7 +65,7 @@ In addition to these system-provided dead-lettering features, applications can u
 This may include messages that cannot be properly processed due to any sort of system issue, messages that hold malformed payloads, or messages that fail 
 authentication when some message-level security scheme is used.
 
-##The Sample
+## The Sample
 
 The sample illustrates system-initiated dead-lettering after exceeding the default ```QueueDescription.MaxDeliveryCount``` of 10 and
 an application-initiated dead-lettering action.

--- a/Deferral/README.md
+++ b/Deferral/README.md
@@ -46,7 +46,7 @@ The sample is a variation of the [ReceiveLoop](../ReceiveLoop) sample.
 
 The send-side of the sample takes an ordered list of workflow steps (Shop, Unpack, Prepare, Cook, Eat) and 
 puts them into the queue. The way we're shuffling these into a random order is by adding a random delay of a few 
-milliseconds (``Task.Delay(rnd.Next(30)```) before each send operation. Sending is done when all send tasks 
+milliseconds (```Task.Delay(rnd.Next(30)```) before each send operation. Sending is done when all send tasks 
 are done.   
 
 ```C#

--- a/DuplicateDetection/readme.md
+++ b/DuplicateDetection/readme.md
@@ -1,4 +1,4 @@
-#Duplicate Detection
+# Duplicate Detection
 
 This sample illustrates the "duplicate detection" feature of the Service Bus client.
 

--- a/DurableSender/readme.md
+++ b/DurableSender/readme.md
@@ -149,7 +149,7 @@ Also note that messages do not expire while they are stored in the MSMQ queue. T
 sets the ```TimeToBeReceived``` property of the MSMQ message to *infinite*. The ```BrokeredMessage.TimeToLive``` value 
 becomes effective when the message is submitted into the Service Bus Queue or Topic.  
 
-##Source Code Files
+## Source Code Files
 * *Client.cs*: Implements a Service Bus client that sends and receives messages to Service Bus using the durable sender library.
 * *DurableMessageSender.cs*: Implements the durable message sender API. Implements code that converts Service Bus brokered messages 
   to and from MSMQ messages and sends and receives MSMQ messages.

--- a/PartitionedQueues/README.md
+++ b/PartitionedQueues/README.md
@@ -1,4 +1,4 @@
-#Partitioned Queues
+# Partitioned Queues
 
 This sample illustrates Partitioned Queues
 

--- a/PrioritySubscriptions/README.md
+++ b/PrioritySubscriptions/README.md
@@ -1,4 +1,4 @@
-#Priority Subscriptions
+# Priority Subscriptions
 
 This sample illustrates how do use topic subscriptions and filters for splitting up a message streams into multiple distinct streams 
 based on certain conditions. The concrete example use-case shown here is prioritization, where we split the message stream into 
@@ -69,7 +69,7 @@ own subscriptions and all values above 2 go into the third subscription.
     }
  ``` 
 
-##Receiver Strategies
+## Receiver Strategies
 
 There are several strategies for how to leverage this topology in an application. 
 

--- a/QueuesGettingStarted/README.md
+++ b/QueuesGettingStarted/README.md
@@ -130,7 +130,7 @@ This is different from the ```ReceiveAndDelete``` alternative where the message 
 Now we start the message receive loop. As explicit receive loops (see the [ReceiveLoop](../ReceiveLoop) sample) can be tricky,
 the vast majority of applications will *and should* instead use the ```OnMessage``` or ```OnMessageAsync``` API. 
 
-> **Unless you have good reason to create your own receive loop, you should use the ```OnMessage```/``ÒnMessageAsync``` API**
+> **Unless you have good reason to create your own receive loop, you should use the ```OnMessage```/```OnMessageAsync``` API**
 
 The ```OnMessage(Async)``` method accepts a callback function for handling a single message, and a set of options:
 
@@ -155,7 +155,7 @@ The asynchronous variant ```OnMessageAsync``` used here accepts an asynchronous 
 > the achievable message flow rate. 
 
 The receive loop will be started as soon as ```OnMessageAsync``` is invoked and will continue in the background when the method 
-has returned. ```OnMessage```/``OnMessageAsync``` can only be called once on any receiver. The receive loop stops when the ````QueueClient```is 
+has returned. ```OnMessage```/```OnMessageAsync``` can only be called once on any receiver. The receive loop stops when the ```QueueClient``` is 
 closed via ```Close()```/```CloseAsync()```. 
 
 > The callback is not invoked on the calling thread. For applications that need synchronization with an UI thread or similar, like 
@@ -262,6 +262,6 @@ sending the messages has not yet completed, we'll wait for the send task to clea
 }
 ```
 
-##Running the sample
+## Running the sample
 
 You can run the application from Visual Studio or on the command line from the sample's root directory by starting ```bin/debug/QueuesGettingStarted.exe```

--- a/QueuesGettingStarted/README.md
+++ b/QueuesGettingStarted/README.md
@@ -1,4 +1,4 @@
-#Getting Started with Service Bus Queues
+# Getting Started with Service Bus Queues
 
 This sample shows the essential API elements for interacting with messages and a Service Bus Queue.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Azure Service Bus Messaging samples
+# Azure Service Bus Messaging samples
 
 This repository contains the official set of samples for the Azure Service Bus Messaging service (Standard and Premium), illustrating all core 
 features of Service Bus Queues and Service Bus Topics.  
@@ -6,7 +6,7 @@ features of Service Bus Queues and Service Bus Topics.
 Fork and play!
 
 
-##Requirements and Setup
+## Requirements and Setup
 
 These samples run against the cloud service and require that you have an active Azure subscription available 
 for use. If you do not have a subscription, [sign up for a free trial](https://azure.microsoft.com/pricing/free-trial/), 
@@ -66,7 +66,7 @@ model is strongly encouraged at all times as it yields significantly more effici
 
 ## Samples
 
-###Getting Started
+### Getting Started
 
 * **Getting Started with Queues** - The [QueuesGettingStarted](./QueuesGettingStarted) sample illustrates the basic send and receive gestures 
   for interacting with a previously provisioned Service Bus Queue. Most other samples in this repository are derivatives of this basic sample. 

--- a/ReceiveLoop/README.md
+++ b/ReceiveLoop/README.md
@@ -1,4 +1,4 @@
-#Receive Loops
+# Receive Loops
 
 This sample is a variation of the [QueuesGettingStarted](../QueuesGettingStarted) sample. This sample does not use the OnMessage API,
 but rather implements an explicit receive loop.  
@@ -167,7 +167,7 @@ absorb the exception (you might want to log it for monitoring purposes) and keep
     }
 ``` 
 
-###Alternate Loop
+### Alternate Loop
 
 A receive loop with a receive operation that is not time-boxed will look like the snippet below. The assumption here is that an operation external 
 to the loop (on a different thread) will terminate the loop by calling *Close* on the *MessageReceiver* instance *receiver*. Closing the receiver
@@ -201,6 +201,6 @@ terminate the loop.
     }
 ``` 
      
-##Running the sample
+## Running the sample
 
 You can run the application from Visual Studio or on the command line from the sample's root directory by starting <code>bin/debug/sample.exe</code>

--- a/SendersReceiversWithQueues/README.md
+++ b/SendersReceiversWithQueues/README.md
@@ -1,4 +1,4 @@
-#Message Senders and Receivers with Service Bus Queues
+# Message Senders and Receivers with Service Bus Queues
 
 This sample shows interacting with Service Bus Queues using a set of API gestures that are more abstract but also a bit more
 flexible than the ``QueueClient`` class introduced in the basic [QueuesGettingStarted](../QueuesGettingStarted) sample. 
@@ -315,6 +315,6 @@ user presses any key sometime after sender and receiver have been kicked off.
     } 
 ```
 
-##Running the sample
+## Running the sample
 
 You can run the application from Visual Studio or on the command line from the sample's root directory by starting <code>bin/debug/sample.exe</code>

--- a/SendersReceiversWithTopics/README.md
+++ b/SendersReceiversWithTopics/README.md
@@ -1,7 +1,7 @@
-#Message Senders and Receivers with Service Bus Topics
+# Message Senders and Receivers with Service Bus Topics
 
 This sample shows how to interact with a Service Bus Topic via the ```MessagingFactory``` and the ```MessageSender``` 
-and ```MessageReceiver``` clients, as an alternative to the ``TopicClient`` and ``SubscriptionClient```class introduced in 
+and ```MessageReceiver``` clients, as an alternative to the ``TopicClient`` and ``SubscriptionClient`` class introduced in 
 the basic [TopicGettingStarted](../TopicsGettingStarted) sample. 
 
 The sample is quasi identical to the [SendersReceiversWithQueues](../SendersReceiversWithQueues) sample since 
@@ -95,6 +95,6 @@ The cancellation token passed to the receiver method is being triggered when the
     }
 ```
 
-##Running the sample
+## Running the sample
 
 You can run the application from Visual Studio or on the command line from the sample's root directory by starting <code>bin/debug/SendersReceiversWithTopics.exe</code>

--- a/SessionState/README.md
+++ b/SessionState/README.md
@@ -1,1 +1,1 @@
-#Managing Session State
+# Managing Session State

--- a/Sessions/README.md
+++ b/Sessions/README.md
@@ -153,7 +153,7 @@ messages originate from the same sender, and how to de-multiplex interleaved mes
 ### Sending
 
 What we do in this sample is to initiate an interleaved send of four independent message sequences, 
-each labeled with a unique ```SessionId``. The interleaved send causes the messages from those
+each labeled with a unique ```SessionId```. The interleaved send causes the messages from those
 four sequences to show up interleaved representing the actual send order, very similar
 to the illustration above.
 
@@ -206,7 +206,7 @@ each message we send.
 }
 ```
 
-Inside the ``Run()``` method, we asynchronously invoke the ```SendMessagesAsync``` 
+Inside the ```Run()``` method, we asynchronously invoke the ```SendMessagesAsync``` 
 four times, which will cause the messages to be sent simultaneously and over separate connections 
 since we're using separate ```MessagingFactory``` instances. Each session's identifier is
 a fresh GUID.    

--- a/TimeToLive/README.md
+++ b/TimeToLive/README.md
@@ -1,1 +1,1 @@
-#Time To Live samples
+# Time To Live samples

--- a/TopicFilters/readme.md
+++ b/TopicFilters/readme.md
@@ -1,4 +1,4 @@
-#Topic Subscription Filters
+# Topic Subscription Filters
 
 This sample illustrates creating filtered subscriptions for topics. It shows a simple *true-filter* that lets all messages pass,
 a filter with a composite SQL-like condition, a rule combining a filter with a set of actions, and a correlation filter 
@@ -114,7 +114,7 @@ the message gets selected for the subscription.
         new SqlFilter("color = 'blue' AND quantity = 10"));
 ```
 
-The following subscription is created with a full ```RuleDescription```, that includes a filter checking for ```color = 'red'````
+The following subscription is created with a full ```RuleDescription```, that includes a filter checking for ```color = 'red'```
 and an action that will modify each matched message. Each matched message will have the 'quantity' property numeric value 
 halved, the 'priority' property removed, and the ```CorrelationId``` system property set to "low".
 
@@ -202,7 +202,7 @@ label value "red" that occurs only once ans thus:
 color=red,quantity=10,priority=high,CorrelationId=high
 ``` 
 
-##Running the sample
+## Running the sample
 
 You can run the application from Visual Studio or on the command line from the sample's root 
 directory by starting <code>bin/debug/sample.exe</code>

--- a/TopicsGettingStarted/README.md
+++ b/TopicsGettingStarted/README.md
@@ -1,4 +1,4 @@
-#Getting Started with Service Bus Topics
+# Getting Started with Service Bus Topics
 
 This sample shows how to interact with the essential API elements for interacting with a Service Bus *Topic*.
 
@@ -40,7 +40,7 @@ of this sample is that we're creating a ``TopicClient`` with a topic instead the
       this.sendClient = TopicClient.CreateFromConnectionString(connectionString, topicName);
 ```
 
-The receive side is also not all that different, but since we#re using a preconfigured *Topic* with three existing subscriptions, we set up and 
+The receive side is also not all that different, but since we're using a preconfigured *Topic* with three existing subscriptions, we set up and 
 initialize three parallel receivers. To receive from a topic subscription, the simplest option is to use a ```SubscriptionClient``` initialized
 with a connection string.  
 
@@ -78,6 +78,6 @@ The ```Run()``` method that is invoked by the common sample entry point first se
 three *Subscriptions* in parallel. The messages received from the *Subscriptions* will differ in color depending on which
 subscription tzhey were received from. 
 
-##Running the sample
+## Running the sample
 
 You can run the application from Visual Studio or on the command line from the sample's root directory by starting <code>bin/debug/TopicsGettingStarted.exe</code>


### PR DESCRIPTION
Several readme files have errors with extra or missing backtick quotes and missing spaces on headings