### PR TITLE
fix propKey substring

### DIFF
--- a/common/Main.cs
+++ b/common/Main.cs
@@ -99,7 +99,7 @@ namespace MessagingSamples
                                 {
                                     continue;
                                 }
-                                var propKey = propl.Substring(0, propi - 1).Trim();
+                                var propKey = propl.Substring(0, propi).Trim();
                                 var propVal = propl.Substring(propi + 1).Trim();
                                 if (properties.ContainsKey(propKey))
                                 {


### PR DESCRIPTION
propi -1 cuts the key one character too soon, so the comparison in #104 is never true, resulting in values from property file never being honored.